### PR TITLE
Change default branch to 'main' in Terraform workflow

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -42,52 +42,62 @@
 #       with:
 #         cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
 
-name: 'Terraform'
+name: Terraform
 
 on:
-  push:
-    branches: [ "master" ]
   pull_request:
+  push:
+    branches: [ "main" ]   # <-- troque para "master" se essa for sua default
 
 permissions:
   contents: read
+  id-token: write          # necessário p/ OIDC (assumir role na AWS)
+
+env:
+  AWS_REGION: sa-east-1
+  TF_IN_AUTOMATION: "true"
 
 jobs:
   terraform:
-    name: 'Terraform'
+    name: Terraform
     runs-on: ubuntu-latest
     environment: production
 
-    # Use the Bash shell regardless whether the GitHub Actions runner is ubuntu-latest, macos-latest, or windows-latest
     defaults:
       run:
         shell: bash
 
     steps:
-    # Checkout the repository to the GitHub Actions runner
-    - name: Checkout
-      uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-    # Install the latest version of Terraform CLI and configure the Terraform CLI configuration file with a Terraform Cloud user API token
-    - name: Setup Terraform
-      uses: hashicorp/setup-terraform@v1
-      with:
-        cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
+      # OIDC: assume um Role na AWS (configure o ARN no secret AWS_ROLE_TO_ASSUME)
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}  # ex: arn:aws:iam::123456789012:role/GitHubActionsTerraformRole
+          aws-region: ${{ env.AWS_REGION }}
 
-    # Initialize a new or existing Terraform working directory by creating initial files, loading any remote state, downloading modules, etc.
-    - name: Terraform Init
-      run: terraform init
+      # Terraform CLI + token do Terraform Cloud
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
 
-    # Checks that all Terraform configuration files adhere to a canonical format
-    - name: Terraform Format
-      run: terraform fmt -check
+      - name: Terraform Init
+        run: terraform init -input=false -upgrade
 
-    # Generates an execution plan for Terraform
-    - name: Terraform Plan
-      run: terraform plan -input=false
+      - name: Terraform Format
+        run: terraform fmt -check
 
-      # On push to "master", build or change infrastructure according to Terraform configuration files
-      # Note: It is recommended to set up a required "strict" status check in your repository for "Terraform Cloud". See the documentation on "strict" required status checks for more information: https://help.github.com/en/github/administering-a-repository/types-of-required-status-checks
-    - name: Terraform Apply
-      if: github.ref == 'refs/heads/"master"' && github.event_name == 'push'
-      run: terraform apply -auto-approve -input=false
+      - name: Terraform Plan (PR)
+        if: github.event_name == 'pull_request'
+        run: terraform plan -no-color -input=false
+
+      - name: Terraform Plan & Apply (push na branch principal)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'  # <-- troque para 'refs/heads/master' se usar master
+        run: |
+          terraform plan -out=tfplan -no-color -input=false
+          terraform apply -auto-approve -input=false tfplan


### PR DESCRIPTION
Updated GitHub Actions workflow for Terraform to use 'main' branch instead of 'master' and improved AWS credentials configuration.